### PR TITLE
Workflow Discord Webhook

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,3 +97,18 @@ jobs:
         asset_name: Emu68-tools-$$.zip # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
         asset_content_type: application/zip # required by GitHub API
         max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
+
+    - name: Declare some variables
+      id: vars
+      shell: bash
+      run: |
+        echo "::set-output name=build_date::$(date +"%Y%m%d")"
+        echo "::set-output name=sha_short::${GITHUB_SHA::6}"
+
+    - name: Webhook
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: "${{ secrets.DISCORD_WEBHOOK }}"
+        method: 'POST'
+        data: '{"username":"Ziggsty the friendly Emu","avatar_url":"https://repository-images.githubusercontent.com/168139345/df1ee280-f4d7-11e9-98df-201401d8d375","content":"[**Emu68-tools**]: New nightly available!","embeds":[{"title":"Emu68-tools-${{ steps.vars.outputs.build_date }}-${{ steps.vars.outputs.sha_short }}.zip","url":"https://github.com/michalsc/Emu68-tools/releases/download/nightly/Emu68-tools-${{ steps.vars.outputs.build_date }}-${{ steps.vars.outputs.sha_short }}.zip"}]}'
+        contentType: "application/json"


### PR DESCRIPTION
This adds so the workflow will post to discord when a new nightly is released like this:
![image](https://user-images.githubusercontent.com/8772229/153773879-839bfe9c-966a-4276-a6e4-8af88b293318.png)

There's a channel in here called **#emu68-nightlies** where this could be posted on PiStorm Discord:
![image](https://user-images.githubusercontent.com/8772229/153777692-85b2f013-c813-47b1-880c-44dcbb583508.png)

All that is required for this to work, is to add a secret called `DISCORD_WEBHOOK` in this repo. There you need to put a discord webhook URL provided from an PiStorm Discord admin for the **#emu68-nightlies** channel

