### PR TITLE
fix(sdcard.device): report TDERR_BadUnitNum when unit not found

### DIFF
--- a/sdcard.device/src/open.c
+++ b/sdcard.device/src/open.c
@@ -30,7 +30,7 @@ void SD_Open(struct IORequest * io asm("a1"), LONG unitNumber asm("d0"), ULONG f
         io->io_Error = TDERR_BadUnitNum;
     }
 
-    /* 
+    /*
         Do whatever necessary to open given unit number with flags, set NT_REPLYMSG if 
         opening device shall complete with success, set io_Error otherwise
     */
@@ -42,7 +42,7 @@ void SD_Open(struct IORequest * io asm("a1"), LONG unitNumber asm("d0"), ULONG f
 
         /* Increase open counter of the unit */
         u->su_Unit.unit_OpenCnt++;
-      
+
         /* Increase global open coutner of the device */
         SDCardBase->sd_Device.dd_Library.lib_OpenCnt++;
         SDCardBase->sd_Device.dd_Library.lib_Flags &= ~LIBF_DELEXP;
@@ -55,6 +55,6 @@ void SD_Open(struct IORequest * io asm("a1"), LONG unitNumber asm("d0"), ULONG f
     {
         io->io_Error = IOERR_OPENFAIL;
     }
-    
+
     /* In contrast to normal library there is no need to return anything */
 }

--- a/sdcard.device/src/open.c
+++ b/sdcard.device/src/open.c
@@ -23,38 +23,31 @@ void SD_Open(struct IORequest * io asm("a1"), LONG unitNumber asm("d0"), ULONG f
         RawDoFmt("[brcm-sdhc] Open(%08lx, %lx, %ld)\n", args, (APTR)putch, NULL);
     }
 
-    io->io_Error = 0;
-
     /* Do not continue if unit number does not fit */
     if (unitNumber >= SDCardBase->sd_UnitCount || (unitNumber == 0 && SDCardBase->sd_HideUnit0)) {
         io->io_Error = TDERR_BadUnitNum;
+        return;
     }
 
     /*
         Do whatever necessary to open given unit number with flags, set NT_REPLYMSG if 
         opening device shall complete with success, set io_Error otherwise
     */
+    io->io_Error = 0;
 
-    if (io->io_Error == 0)
-    {
-        /* Get unit based on unit number */
-        struct SDCardUnit *u = SDCardBase->sd_Units[unitNumber];
+    /* Get unit based on unit number */
+    struct SDCardUnit *u = SDCardBase->sd_Units[unitNumber];
 
-        /* Increase open counter of the unit */
-        u->su_Unit.unit_OpenCnt++;
+    /* Increase open counter of the unit */
+    u->su_Unit.unit_OpenCnt++;
 
-        /* Increase global open coutner of the device */
-        SDCardBase->sd_Device.dd_Library.lib_OpenCnt++;
-        SDCardBase->sd_Device.dd_Library.lib_Flags &= ~LIBF_DELEXP;
+    /* Increase global open coutner of the device */
+    SDCardBase->sd_Device.dd_Library.lib_OpenCnt++;
+    SDCardBase->sd_Device.dd_Library.lib_Flags &= ~LIBF_DELEXP;
 
-        io->io_Unit = &u->su_Unit;
-        io->io_Unit->unit_flags |= UNITF_ACTIVE;
-        io->io_Message.mn_Node.ln_Type = NT_REPLYMSG;
-    }
-    else
-    {
-        io->io_Error = IOERR_OPENFAIL;
-    }
+    io->io_Unit = &u->su_Unit;
+    io->io_Unit->unit_flags |= UNITF_ACTIVE;
+    io->io_Message.mn_Node.ln_Type = NT_REPLYMSG;
 
     /* In contrast to normal library there is no need to return anything */
 }


### PR DESCRIPTION
The intention according to the comment is not to continue if the unit is
not found, so we should set the error code and return immediately.

This is the only error case in function, so the conditionals around the
rest of the process become redundant.

That TDERR_BadUnitNum rather than IOERR_OPENFAIL is the correct code for
the error case was determined in conversation with _Bnu on the PiStorm
Discord.

This has been tested with HDToolbox from a Workbench 3.1 install disk which was
previously failing to enumerate the units unless `SCSI_MAX_LUN` was set to `0`.

Regression testing with other versions may be required.