### PR TITLE
Video core no fpu

### DIFF
--- a/VC4Tweak/CMakeLists.txt
+++ b/VC4Tweak/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(VC4Tweak VERSION 1.0.0)
+project(VC4Tweak VERSION 1.1.0)
 get_verstring(VERSTRING)
 
 add_link_options(-ffreestanding -m68030 -nostdlib -nostartfiles -Wl,-e,__start)

--- a/VC4Tweak/CMakeLists.txt
+++ b/VC4Tweak/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.14.0)
 project(VC4Tweak VERSION 1.0.0)
 get_verstring(VERSTRING)
 
-add_link_options(-ffreestanding -m68040 -nostdlib -nostartfiles -Wl,-e,__start)
-add_compile_options(-Os -m68040 -fomit-frame-pointer)
+add_link_options(-ffreestanding -m68030 -nostdlib -nostartfiles -Wl,-e,__start)
+add_compile_options(-Os -m68030 -fomit-frame-pointer)
 add_compile_definitions(PRIVATE VERSION_STRING="${VERSTRING}")
 
 add_executable(VC4Tweak

--- a/VideoCore.card/CMakeLists.txt
+++ b/VideoCore.card/CMakeLists.txt
@@ -3,7 +3,7 @@ project(VideoCore VERSION 1.0.0)
 get_verstring(VERSTRING)
 
 add_link_options(-ffreestanding -nostdlib -nostartfiles -Wl,-e,__start)
-add_compile_options(-Os -m68040 -fomit-frame-pointer)
+add_compile_options(-Os -m68030 -fomit-frame-pointer)
 add_compile_definitions(PRIVATE VERSION_STRING="${VERSTRING}")
 
 add_library(VideoCore INTERFACE)

--- a/VideoCore.card/CMakeLists.txt
+++ b/VideoCore.card/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(VideoCore.card
     src/debug.c
     src/end.c
 )
-target_link_libraries(VideoCore.card devicetree amiga)
+target_link_libraries(VideoCore.card devicetree amiga common)
 target_compile_definitions(VideoCore.card PUBLIC CARD_NAME="VideoCore.card")
 
 add_executable(Emu68-VC4.card
@@ -30,7 +30,7 @@ add_executable(Emu68-VC4.card
     src/debug.c
     src/end.c
 )
-target_link_libraries(Emu68-VC4.card devicetree amiga)
+target_link_libraries(Emu68-VC4.card devicetree amiga common)
 target_compile_definitions(Emu68-VC4.card PUBLIC CARD_NAME="Emu68-VC4.card")
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/VideoCore.card DESTINATION ./VideoCore/)

--- a/VideoCore.card/CMakeLists.txt
+++ b/VideoCore.card/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(VideoCore VERSION 1.0.0)
+project(VideoCore VERSION 1.1.0)
 get_verstring(VERSTRING)
 
 add_link_options(-ffreestanding -nostdlib -nostartfiles -Wl,-e,__start)

--- a/VideoCore.card/src/emu68-vc4.h
+++ b/VideoCore.card/src/emu68-vc4.h
@@ -63,8 +63,8 @@ struct VC4Base {
     ULONG                   vc4_Scaler;
     UBYTE                   vc4_Phase;
     ULONG                   vc4_VertFreq;
-    double                  vc4_Kernel_B;
-    double                  vc4_Kernel_C;
+    ULONG                   vc4_Kernel_B; // FLOAT!
+    ULONG                   vc4_Kernel_C; // FLOAT!
     UBYTE                   vc4_UseKernel;
     UBYTE                   vc4_SpriteAlpha;
     UBYTE                   vc4_SpriteVisible;

--- a/VideoCore.card/src/main.c
+++ b/VideoCore.card/src/main.c
@@ -17,6 +17,7 @@
 #include <proto/devicetree.h>
 
 #include <stdint.h>
+#include <common/compiler.h>
 
 // Shut off MathIEEE float injecting stuff
 #define FLOAT ULONG
@@ -87,7 +88,7 @@ int _strcmp(const char *s1, const char *s2)
     return (*(const unsigned char *)s1 - *(const unsigned char *)(s2 - 1));
 }
 
-static int FindCard(struct BoardInfo* bi asm("a0"), struct VC4Base *VC4Base asm("a6"))
+static int FindCard(REGARG(struct BoardInfo* bi, "a0"), REGARG(struct VC4Base *VC4Base, "a6"))
 {
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     APTR DeviceTreeBase = NULL;
@@ -437,7 +438,7 @@ static void vc4_Task()
     DeleteMsgPort(port);
 }
 
-static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("a1"), struct VC4Base *VC4Base asm("a6"))
+static int InitCard(REGARG(struct BoardInfo* bi, "a0"), REGARG(const char **ToolTypes, "a1"), REGARG(struct VC4Base *VC4Base, "a6"))
 {
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     struct Library *MathIeeeSingBasBase = OpenLibrary("mathieeesingbas.library", 0);
@@ -857,7 +858,7 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
     return 1;
 }
 
-static struct VC4Base * OpenLib(ULONG version asm("d0"), struct VC4Base *VC4Base asm("a6"))
+static struct VC4Base * OpenLib(REGARG(ULONG version, "d0"), REGARG(struct VC4Base *VC4Base, "a6"))
 {
     struct ExecBase *SysBase = *(struct ExecBase **)4;
     VC4Base->vc4_LibNode.LibBase.lib_OpenCnt++;
@@ -868,7 +869,7 @@ static struct VC4Base * OpenLib(ULONG version asm("d0"), struct VC4Base *VC4Base
     return VC4Base;
 }
 
-static ULONG ExpungeLib(struct VC4Base *VC4Base asm("a6"))
+static ULONG ExpungeLib(REGARG(struct VC4Base *VC4Base, "a6"))
 {
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     BPTR segList = 0;
@@ -906,7 +907,7 @@ static ULONG ExpungeLib(struct VC4Base *VC4Base asm("a6"))
     return segList;
 }
 
-static ULONG CloseLib(struct VC4Base *VC4Base asm("a6"))
+static ULONG CloseLib(REGARG(struct VC4Base *VC4Base, "a6"))
 {
     if (VC4Base->vc4_LibNode.LibBase.lib_OpenCnt != 0)
         VC4Base->vc4_LibNode.LibBase.lib_OpenCnt--;
@@ -926,7 +927,7 @@ static uint32_t ExtFunc()
     return 0;
 }
 
-struct VC4Base * vc4_Init(struct VC4Base *base asm("d0"), BPTR seglist asm("a0"), struct ExecBase *SysBase asm("a6"))
+struct VC4Base * vc4_Init(REGARG(struct VC4Base *base, "d0"), REGARG(BPTR seglist, "a0"), REGARG(struct ExecBase *SysBase, "a6"))
 {
     struct VC4Base *VC4Base = base;
     VC4Base->vc4_SegList = seglist;

--- a/VideoCore.card/src/main.c
+++ b/VideoCore.card/src/main.c
@@ -8,6 +8,7 @@
 #include <clib/debug_protos.h>
 #include <devices/inputevent.h>
 
+#include <proto/mathieeesingbas.h>
 #include <proto/exec.h>
 #include <proto/expansion.h>
 #include <proto/dos.h>
@@ -16,6 +17,9 @@
 #include <proto/devicetree.h>
 
 #include <stdint.h>
+
+// Shut off MathIEEE float injecting stuff
+#define FLOAT ULONG
 
 #include "boardinfo.h"
 #include "emu68-vc4.h"
@@ -436,6 +440,10 @@ static void vc4_Task()
 static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("a1"), struct VC4Base *VC4Base asm("a6"))
 {
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
+    struct Library *MathIeeeSingBasBase = OpenLibrary("mathieeesingbas.library", 0);
+
+    if (MathIeeeSingBasBase == NULL)
+        return 0;
 
     bi->CardBase = (struct CardBase *)VC4Base;
     bi->ExecBase = VC4Base->vc4_SysBase;
@@ -620,14 +628,20 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
 
     Enable();
 
-    double delta = (double)(tick2 - tick1);
-    double hz = 1000000.0 / delta;
+    const ULONG float_1000000 = 0x49742400;
+    const ULONG float_1000 = 0x447a0000;
+    const ULONG float_0p5 = 0x3f000000;
 
-    ULONG mHz = 1000.0 * hz;
+    ULONG delta = IEEESPFlt(tick2 - tick1);
+    ULONG hz = IEEESPDiv(float_1000000, delta);
+    ULONG mHz = IEEESPMul(float_1000, hz);
+    mHz = IEEESPAdd(mHz, float_0p5);   // + 0.5
+    mHz = IEEESPFix(mHz);
+    hz = IEEESPAdd(hz, float_0p5);
+    hz = IEEESPFix(hz);
 
     bug("[VC] Detected refresh rate of %ld.%03ld Hz\n", mHz / 1000, mHz % 1000);
-
-    VC4Base->vc4_VertFreq = (ULONG)(hz+0.5);
+    VC4Base->vc4_VertFreq = hz;
 
     VC4Base->vc4_Phase = 128;
     VC4Base->vc4_Scaler = 0xc0000000;
@@ -635,6 +649,8 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
     VC4Base->vc4_SpriteAlpha = 255;
     VC4Base->vc4_SwitchMode = None;
     VC4Base->vc4_SwitchInverted = 0;
+    VC4Base->vc4_Kernel_B = 0x3e800000; // 0.25
+    VC4Base->vc4_Kernel_C = 0x3f400000; // 0.75
 
     for (;ToolTypes[0] != NULL; ToolTypes++)
     {
@@ -720,7 +736,10 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
                 num = num * 10 + (*c++ - '0');
             }
 
-            VC4Base->vc4_Kernel_B = (double)num / 1000.0;
+            VC4Base->vc4_Kernel_B = IEEESPDiv(
+                IEEESPFlt(num),
+                0x447a0000  // 1000.0
+            );
 
             bug("[VC] Mitchel-Netravali B %ld\n", num);
         }
@@ -753,7 +772,10 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
                 num = num * 10 + (*c++ - '0');
             }
 
-            VC4Base->vc4_Kernel_C = (double)num / 1000.0;
+            VC4Base->vc4_Kernel_C = IEEESPDiv(
+                IEEESPFlt(num),
+                0x447a0000  // 1000.0
+            );
 
             bug("[VC] Mitchel-Netravali C %ld\n", num);
         }
@@ -829,6 +851,8 @@ static int InitCard(struct BoardInfo* bi asm("a0"), const char **ToolTypes asm("
     VC4Base->vc4_SpriteShape = AllocMem(MAXSPRITEWIDTH * MAXSPRITEHEIGHT, MEMF_FAST | MEMF_REVERSE | MEMF_CLEAR);
 
     bug("[VC] InitCard ready\n");
+
+    CloseLibrary(MathIeeeSingBasBase);
 
     return 1;
 }

--- a/VideoCore.card/src/messages.h
+++ b/VideoCore.card/src/messages.h
@@ -26,14 +26,14 @@ struct VC4Msg {
 
         struct {
             UBYTE kernel;
-            double b;
-            double c;
+            ULONG b; // FLOAT!
+            ULONG c; // FLOAT!
         } SetKernel;
 
         struct {
             UBYTE kernel;
-            double b;
-            double c;
+            ULONG b; // FLOAT!
+            ULONG c; // FLOAT!
             WORD kernel_val[16];
         } GetKernel;
     };

--- a/VideoCore.card/src/vc4.c
+++ b/VideoCore.card/src/vc4.c
@@ -6,6 +6,8 @@
 #include <proto/mathieeesingbas.h>
 #include <hardware/cia.h>
 
+#include <common/compiler.h>
+
 /* Make sure MathIEEE will not force gcc to do weird FLOT convertions when calling lib functions */
 #define FLOAT ULONG
 
@@ -214,7 +216,7 @@ int compute_nearest_neighbour_kernel(uint32_t *dlist_memory)
     return kernel_start;
 }
 
-UWORD CalculateBytesPerRow(struct BoardInfo *b asm("a0"), UWORD width asm("d0"), RGBFTYPE format asm("d7"))
+UWORD CalculateBytesPerRow(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD width, "d0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -250,7 +252,7 @@ UWORD CalculateBytesPerRow(struct BoardInfo *b asm("a0"), UWORD width asm("d0"),
     }
 }
 
-void SetDAC(struct BoardInfo *b asm("a0"), RGBFTYPE format asm("d7"))
+void SetDAC(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -262,7 +264,7 @@ void SetDAC(struct BoardInfo *b asm("a0"), RGBFTYPE format asm("d7"))
 }
 
 
-void SetGC(struct BoardInfo *b asm("a0"), struct ModeInfo *mode_info asm("a1"), BOOL border asm("d0"))
+void SetGC(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"), REGARG(BOOL border, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -289,7 +291,7 @@ void SetGC(struct BoardInfo *b asm("a0"), struct ModeInfo *mode_info asm("a1"), 
     }
 }
 
-UWORD SetSwitch(struct BoardInfo *b asm("a0"), UWORD enabled asm("d0"))
+UWORD SetSwitch(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD enabled, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -392,7 +394,9 @@ int AllocSlot(UWORD size, struct VC4Base *VC4Base)
     return ret;
 }
 
-void SetPanning (struct BoardInfo *b asm("a0"), UBYTE *addr asm("a1"), UWORD width asm("d0"), WORD x_offset asm("d1"), WORD y_offset asm("d2"), RGBFTYPE format asm("d7"))
+void SetPanning(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE *addr, "a1"), 
+                REGARG(UWORD width, "d0"), REGARG(WORD x_offset, "d1"), REGARG(WORD y_offset, "d2"), 
+                REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -706,7 +710,8 @@ void SetPanning (struct BoardInfo *b asm("a0"), UBYTE *addr asm("a1"), UWORD wid
 }
 
 
-void SetColorArray (__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __REGD1(UWORD num)) {
+void SetColorArray(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD start, "d0"), REGARG(UWORD num, "d1"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     volatile uint32_t *displist = (uint32_t *)0xf2402000;
@@ -729,7 +734,8 @@ void SetColorArray (__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __REGD1(
 }
 
 
-APTR CalculateMemory (__REGA0(struct BoardInfo *b), __REGA1(unsigned long addr), __REGD7(RGBFTYPE format)) {
+APTR CalculateMemory(REGARG(struct BoardInfo *b, "a0"), REGARG(unsigned long addr, "a1"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
 
@@ -740,7 +746,6 @@ APTR CalculateMemory (__REGA0(struct BoardInfo *b), __REGA1(unsigned long addr),
 
     return (APTR)addr;
 }
-
 
 enum fake_rgbftypes {
     RGBF_8BPP_CLUT,
@@ -766,7 +771,8 @@ enum fake_rgbftypes {
 };
 #define BIP(a) (1 << a)
 
-ULONG GetCompatibleFormats (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format)) {
+ULONG GetCompatibleFormats(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     if (0)
@@ -778,7 +784,7 @@ ULONG GetCompatibleFormats (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE forma
 }
 
 //static int display_enabled = 0;
-UWORD SetDisplay (__REGA0(struct BoardInfo *b), __REGD0(UWORD enabled))
+UWORD SetDisplay(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD enabled, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -797,8 +803,9 @@ UWORD SetDisplay (__REGA0(struct BoardInfo *b), __REGD0(UWORD enabled))
 }
 
 
-LONG ResolvePixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode_info), __REGD0(ULONG pixel_clock), __REGD7(RGBFTYPE format)) {
-
+LONG ResolvePixelClock(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"),
+                       REGARG(ULONG pixel_clock, "d0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     
@@ -819,7 +826,9 @@ LONG ResolvePixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *m
     return 0;
 }
 
-ULONG GetPixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode_info), __REGD0(ULONG index), __REGD7(RGBFTYPE format)) {
+ULONG GetPixelClock(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"),
+                    REGARG(ULONG index, "d0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     
     ULONG clock = mode_info->HorTotal * mode_info->VerTotal * VC4Base->vc4_VertFreq;
@@ -831,21 +840,27 @@ ULONG GetPixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode
 }
 
 // None of these five really have to do anything.
-void SetClock (__REGA0(struct BoardInfo *b)) {
-}
-void SetMemoryMode (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format)) {
-}
-
-void SetWriteMask (__REGA0(struct BoardInfo *b), __REGD0(UBYTE mask)) {
+void SetClock(REGARG(struct BoardInfo *b, "a0"))
+{
 }
 
-void SetClearMask (__REGA0(struct BoardInfo *b), __REGD0(UBYTE mask)) {
+void SetMemoryMode(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
+{
 }
 
-void SetReadPlane (__REGA0(struct BoardInfo *b), __REGD0(UBYTE plane)) {
+void SetWriteMask(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE mask, "d0"))
+{
 }
 
-void SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL enable), __REGD7(RGBFTYPE format))
+void SetClearMask(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE mask, "d0"))
+{
+}
+
+void SetReadPlane(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE plane, "d0"))
+{
+}
+
+void SetSprite(REGARG(struct BoardInfo *b, "a0"), REGARG(BOOL enable, "d0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
 
@@ -877,7 +892,8 @@ void SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL enable), __REGD7(RGBF
     }
 }
 
-void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format))
+void SetSpritePosition(REGARG(struct BoardInfo *b, "a0"), REGARG(WORD x, "d0"),
+                       REGARG(WORD y, "d1"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
 
@@ -914,7 +930,7 @@ void SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(W
 }
 
 
-void SetSpriteImage (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format))
+void SetSpriteImage(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = *(struct ExecBase **)4;
@@ -981,7 +997,9 @@ void SetSpriteImage (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format))
     CacheClearE(VC4Base->vc4_SpriteShape, MAXSPRITEHEIGHT * MAXSPRITEWIDTH, CACRF_ClearD);
 }
 
-void SetSpriteColor (__REGA0(struct BoardInfo *b), __REGD0(UBYTE idx), __REGD1(UBYTE R), __REGD2(UBYTE G), __REGD3(UBYTE B), __REGD7(RGBFTYPE format))
+void SetSpriteColor(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE idx, "d0"),
+                    REGARG(UBYTE R, "d1"), REGARG(UBYTE G, "d2"), REGARG(UBYTE B, "d3"),
+                    REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     if (idx < 3) {
@@ -992,7 +1010,7 @@ void SetSpriteColor (__REGA0(struct BoardInfo *b), __REGD0(UBYTE idx), __REGD1(U
     }
 }
 
-ULONG GetVBeamPos(struct BoardInfo *b asm("a0"))
+ULONG GetVBeamPos(REGARG(struct BoardInfo *b, "a0"))
 {
     volatile ULONG *stat = (ULONG*)(0xf2400000 + SCALER_DISPSTAT1);
     ULONG vbeampos = LE32(*stat) & 0xfff;
@@ -1000,7 +1018,8 @@ ULONG GetVBeamPos(struct BoardInfo *b asm("a0"))
     return vbeampos;
 }
 
-void WaitVerticalSync (__REGA0(struct BoardInfo *b), __REGD0(BOOL toggle)) {
+void WaitVerticalSync(REGARG(struct BoardInfo *b, "a0"), REGARG(BOOL toggle, "d0"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     volatile ULONG *stat = (ULONG*)(0xf2400000 + SCALER_DISPSTAT1);
 

--- a/VideoCore.card/src/vc4.c
+++ b/VideoCore.card/src/vc4.c
@@ -19,16 +19,17 @@ int mitchell_netravali(ULONG x, ULONG b, ULONG c, struct Library *MathIeeeSingBa
     const ULONG float_6 = 0x40c00000;
     const ULONG float_0p5 = 0x3f000000;
     const ULONG float_255 = 0x437f0000;
+    const ULONG float_2 = 0x40000000;
+    const ULONG float_1 = 0x3f800000;
 
     ULONG k;
 
     x = IEEESPAbs(x);
     
-    if (x < 1) {
+    if (IEEESPCmp(x, float_1) < 0) {
         const ULONG float_18 = 0x41900000;
         const ULONG float_12 = 0x41400000;
         const ULONG float_9 = 0x41100000;
-        const ULONG float_2 = 0x40000000;
         
         ULONG a1, a2, a3;
         a1 = IEEESPAdd(
@@ -64,7 +65,7 @@ int mitchell_netravali(ULONG x, ULONG b, ULONG c, struct Library *MathIeeeSingBa
         k = IEEESPAdd(IEEESPAdd(a1, a2), a3);
         //k = (12.0 - 9.0 * b - 6.0 * c) * x * x * x + (-18.0 + 12.0 * b + 6.0 * c) * x * x + (6.0 - 2.0 * b);
     }
-    else if (x < 2) {
+    else if (IEEESPCmp(x, float_2) < 0) {
         const ULONG float_8 = 0x41000000;
         const ULONG float_24 = 0x41c00000;
         const ULONG float_30 = 0x41f00000;

--- a/VideoCore.card/src/vc4.h
+++ b/VideoCore.card/src/vc4.h
@@ -78,6 +78,6 @@ extern int unity_kernel;
 extern int kernel_start;
 
 int compute_nearest_neighbour_kernel(uint32_t *dlist_memory);
-int compute_scaling_kernel(uint32_t *dlist_memory, double b, double c);
+int compute_scaling_kernel(uint32_t *dlist_memory, ULONG b, ULONG c);
 
 #endif /* _VC4_H */

--- a/VideoCore.card/src/vc6.c
+++ b/VideoCore.card/src/vc6.c
@@ -4,13 +4,14 @@
 
 #include <proto/exec.h>
 #include <hardware/cia.h>
+#include <common/compiler.h>
 
 #include "emu68-vc4.h"
 #include "vc6.h"
 #include "boardinfo.h"
 #include "mbox.h"
 
-UWORD VC6_CalculateBytesPerRow(struct BoardInfo *b asm("a0"), UWORD width asm("d0"), RGBFTYPE format asm("d7"))
+UWORD VC6_CalculateBytesPerRow(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD width, "d0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -46,7 +47,7 @@ UWORD VC6_CalculateBytesPerRow(struct BoardInfo *b asm("a0"), UWORD width asm("d
     }
 }
 
-void VC6_SetDAC(struct BoardInfo *b asm("a0"), RGBFTYPE format asm("d7"))
+void VC6_SetDAC(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -57,8 +58,7 @@ void VC6_SetDAC(struct BoardInfo *b asm("a0"), RGBFTYPE format asm("d7"))
     // This needs no handling, since the PiStorm doesn't really have a RAMDAC or a video card chipset.
 }
 
-
-void VC6_SetGC(struct BoardInfo *b asm("a0"), struct ModeInfo *mode_info asm("a1"), BOOL border asm("d0"))
+void VC6_SetGC(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"), REGARG(BOOL border, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -85,7 +85,7 @@ void VC6_SetGC(struct BoardInfo *b asm("a0"), struct ModeInfo *mode_info asm("a1
     }
 }
 
-UWORD VC6_SetSwitch(struct BoardInfo *b asm("a0"), UWORD enabled asm("d0"))
+UWORD VC6_SetSwitch(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD enabled, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -188,7 +188,9 @@ int VC6_AllocSlot(UWORD size, struct VC4Base *VC4Base)
     return ret;
 }
 
-void VC6_SetPanning (struct BoardInfo *b asm("a0"), UBYTE *addr asm("a1"), UWORD width asm("d0"), WORD x_offset asm("d1"), WORD y_offset asm("d2"), RGBFTYPE format asm("d7"))
+void VC6_SetPanning(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE *addr, "a1"), 
+                    REGARG(UWORD width, "d0"), REGARG(WORD x_offset, "d1"), 
+                    REGARG(WORD y_offset, "d2"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -522,8 +524,8 @@ void VC6_SetPanning (struct BoardInfo *b asm("a0"), UBYTE *addr asm("a1"), UWORD
     }
 }
 
-
-void VC6_SetColorArray (__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __REGD1(UWORD num)) {
+void VC6_SetColorArray(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD start, "d0"), REGARG(UWORD num, "d1"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     volatile uint32_t *displist = (uint32_t *)0xf2404000;
@@ -546,7 +548,9 @@ void VC6_SetColorArray (__REGA0(struct BoardInfo *b), __REGD0(UWORD start), __RE
 }
 
 
-APTR VC6_CalculateMemory (__REGA0(struct BoardInfo *b), __REGA1(unsigned long addr), __REGD7(RGBFTYPE format)) {
+APTR VC6_CalculateMemory(REGARG(struct BoardInfo *b, "a0"), REGARG(unsigned long addr, "a1"), 
+                         REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
 
@@ -583,7 +587,8 @@ enum fake_rgbftypes {
 };
 #define BIP(a) (1 << a)
 
-ULONG VC6_GetCompatibleFormats (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format)) {
+ULONG VC6_GetCompatibleFormats(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     if (0)
@@ -595,7 +600,7 @@ ULONG VC6_GetCompatibleFormats (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE f
 }
 
 //static int display_enabled = 0;
-UWORD VC6_SetDisplay (__REGA0(struct BoardInfo *b), __REGD0(UWORD enabled))
+UWORD VC6_SetDisplay(REGARG(struct BoardInfo *b, "a0"), REGARG(UWORD enabled, "d0"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
@@ -613,9 +618,9 @@ UWORD VC6_SetDisplay (__REGA0(struct BoardInfo *b), __REGD0(UWORD enabled))
     return 1;
 }
 
-
-LONG VC6_ResolvePixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode_info), __REGD0(ULONG pixel_clock), __REGD7(RGBFTYPE format)) {
-
+LONG VC6_ResolvePixelClock(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"),
+                           REGARG(ULONG pixel_clock, "d0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = VC4Base->vc4_SysBase;
     
@@ -636,7 +641,9 @@ LONG VC6_ResolvePixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInf
     return 0;
 }
 
-ULONG VC6_GetPixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *mode_info), __REGD0(ULONG index), __REGD7(RGBFTYPE format)) {
+ULONG VC6_GetPixelClock(REGARG(struct BoardInfo *b, "a0"), REGARG(struct ModeInfo *mode_info, "a1"),
+                        REGARG(ULONG index, "d0"), REGARG(RGBFTYPE format, "d7"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     
     ULONG clock = mode_info->HorTotal * mode_info->VerTotal * VC4Base->vc4_VertFreq;
@@ -648,21 +655,27 @@ ULONG VC6_GetPixelClock (__REGA0(struct BoardInfo *b), __REGA1(struct ModeInfo *
 }
 
 // None of these five really have to do anything.
-void VC6_SetClock (__REGA0(struct BoardInfo *b)) {
-}
-void VC6_SetMemoryMode (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format)) {
-}
-
-void VC6_SetWriteMask (__REGA0(struct BoardInfo *b), __REGD0(UBYTE mask)) {
+void VC6_SetClock(REGARG(struct BoardInfo *b, "a0"))
+{
 }
 
-void VC6_SetClearMask (__REGA0(struct BoardInfo *b), __REGD0(UBYTE mask)) {
+void VC6_SetMemoryMode(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
+{
 }
 
-void VC6_SetReadPlane (__REGA0(struct BoardInfo *b), __REGD0(UBYTE plane)) {
+void VC6_SetWriteMask(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE mask, "d0"))
+{
 }
 
-void VC6_SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL enable), __REGD7(RGBFTYPE format))
+void VC6_SetClearMask(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE mask, "d0"))
+{
+}
+
+void VC6_SetReadPlane(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE plane, "d0"))
+{
+}
+
+void VC6_SetSprite(REGARG(struct BoardInfo *b, "a0"), REGARG(BOOL enable, "d0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
 
@@ -694,7 +707,8 @@ void VC6_SetSprite (__REGA0(struct BoardInfo *b), __REGD0(BOOL enable), __REGD7(
     }
 }
 
-void VC6_SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REGD1(WORD y), __REGD7(RGBFTYPE format))
+void VC6_SetSpritePosition(REGARG(struct BoardInfo *b, "a0"), REGARG(WORD x, "d0"), 
+                           REGARG(WORD y, "d1"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
 
@@ -730,8 +744,7 @@ void VC6_SetSpritePosition (__REGA0(struct BoardInfo *b), __REGD0(WORD x), __REG
     }
 }
 
-
-void VC6_SetSpriteImage (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format))
+void VC6_SetSpriteImage(REGARG(struct BoardInfo *b, "a0"), REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     struct ExecBase *SysBase = *(struct ExecBase **)4;
@@ -798,7 +811,9 @@ void VC6_SetSpriteImage (__REGA0(struct BoardInfo *b), __REGD7(RGBFTYPE format))
     CacheClearE(VC4Base->vc4_SpriteShape, MAXSPRITEHEIGHT * MAXSPRITEWIDTH, CACRF_ClearD);
 }
 
-void VC6_SetSpriteColor (__REGA0(struct BoardInfo *b), __REGD0(UBYTE idx), __REGD1(UBYTE R), __REGD2(UBYTE G), __REGD3(UBYTE B), __REGD7(RGBFTYPE format))
+void VC6_SetSpriteColor(REGARG(struct BoardInfo *b, "a0"), REGARG(UBYTE idx, "d0"),
+                        REGARG(UBYTE R, "d1"), REGARG(UBYTE G, "d2"), REGARG(UBYTE B, "d3"),
+                        REGARG(RGBFTYPE format, "d7"))
 {
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     if (idx < 3) {
@@ -809,7 +824,7 @@ void VC6_SetSpriteColor (__REGA0(struct BoardInfo *b), __REGD0(UBYTE idx), __REG
     }
 }
 
-ULONG VC6_GetVBeamPos(struct BoardInfo *b asm("a0"))
+ULONG VC6_GetVBeamPos(REGARG(struct BoardInfo *b, "a0"))
 {
     volatile ULONG *stat = (ULONG*)(0xf2400000 + SCALER_DISPSTAT1);
     ULONG vbeampos = LE32(*stat) & 0xfff;
@@ -817,7 +832,8 @@ ULONG VC6_GetVBeamPos(struct BoardInfo *b asm("a0"))
     return vbeampos;
 }
 
-void VC6_WaitVerticalSync (__REGA0(struct BoardInfo *b), __REGD0(BOOL toggle)) {
+void VC6_WaitVerticalSync(REGARG(struct BoardInfo *b, "a0"), REGARG(BOOL toggle, "d0"))
+{
     struct VC4Base *VC4Base = (struct VC4Base *)b->CardBase;
     volatile ULONG *stat = (ULONG*)(0xf2400000 + SCALER_DISPSTAT1);
 

--- a/VideoCore.card/src/vc6.h
+++ b/VideoCore.card/src/vc6.h
@@ -80,6 +80,6 @@ extern int unity_kernel;
 extern int kernel_start;
 
 int compute_nearest_neighbour_kernel(uint32_t *dlist_memory);
-int compute_scaling_kernel(uint32_t *dlist_memory, double b, double c);
+int compute_scaling_kernel(uint32_t *dlist_memory, ULONG b, ULONG c);
 
 #endif /* _VC6_H */


### PR DESCRIPTION
Starting with this version VideoCore and Emu68-VC4 do not use FPU for computation of scaling kernel. Instead, mathieeesingbas.library is used.